### PR TITLE
Replace +/− button with C (clear entry)

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -14,7 +14,7 @@
     </div>
     <div class="buttons">
       <button class="btn op" data-action="clear">AC</button>
-      <button class="btn op" data-action="toggle-sign">+/−</button>
+      <button class="btn op" data-action="clear-entry">C</button>
       <button class="btn op" data-action="percent">%</button>
       <button class="btn op accent" data-action="operator" data-value="/">÷</button>
 

--- a/public/script.js
+++ b/public/script.js
@@ -89,13 +89,10 @@
     updateDisplay();
   }
 
-  function handleToggleSign() {
-    if (currentInput !== '0' && currentInput !== 'Error') {
-      currentInput = currentInput.startsWith('-')
-        ? currentInput.slice(1)
-        : '-' + currentInput;
-      updateDisplay();
-    }
+  function handleClearEntry() {
+    currentInput = '0';
+    shouldResetInput = false;
+    updateDisplay();
   }
 
   function handlePercent() {
@@ -117,8 +114,8 @@
       case 'operator':    handleOperator(value); break;
       case 'equals':      handleEquals(); break;
       case 'clear':       handleClear(); break;
+      case 'clear-entry': handleClearEntry(); break;
       case 'decimal':     handleDecimal(); break;
-      case 'toggle-sign': handleToggleSign(); break;
       case 'percent':     handlePercent(); break;
     }
   });


### PR DESCRIPTION
Swaps the `+/−` (toggle sign) button in the top row for a `C` (clear entry) button.

- `C` clears only the current input, preserving the pending operator and previous operand, so users can correct a mistyped second operand without restarting the whole expression.
- `AC` continues to fully reset the calculator state.

Touches `public/index.html` (button markup) and `public/script.js` (new `handleClearEntry` handler, removed `handleToggleSign`).